### PR TITLE
Support scopes in relationships

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -78,6 +78,8 @@ module Formtastic
                     ) if reflection.options[:polymorphic] == true
             end
 
+            return reflection.klass.merge(reflection.scope) if reflection.scope
+
             conditions_from_reflection = (reflection.respond_to?(:options) && reflection.options[:conditions]) || {}
             conditions_from_reflection = conditions_from_reflection.call if conditions_from_reflection.is_a?(Proc)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -251,7 +251,7 @@ module FormtasticSpecHelper
     allow(::Author).to receive(:where).and_return(author_array_or_scope)
     allow(::Author).to receive(:human_attribute_name) { |column_name| column_name.humanize }
     allow(::Author).to receive(:human_name).and_return('::Author')
-    allow(::Author).to receive(:reflect_on_association) { |column_name| double('reflection', :options => {}, :klass => Post, :macro => :has_many) if column_name == :posts }
+    allow(::Author).to receive(:reflect_on_association) { |column_name| double('reflection', :scope => nil, :options => {}, :klass => Post, :macro => :has_many) if column_name == :posts }
     allow(::Author).to receive(:content_columns).and_return([double('column', :name => 'login'), double('column', :name => 'created_at')])
     allow(::Author).to receive(:to_key).and_return(nil)
     allow(::Author).to receive(:persisted?).and_return(nil)
@@ -304,21 +304,22 @@ module FormtasticSpecHelper
     allow(::Post).to receive(:reflect_on_association) { |column_name|
       case column_name
       when :author, :author_status
-        mock = double('reflection', :options => {}, :klass => ::Author, :macro => :belongs_to)
+        mock = double('reflection', :scope => nil, :options => {}, :klass => ::Author, :macro => :belongs_to)
         allow(mock).to receive(:[]).with(:class_name).and_return("Author")
         mock
       when :reviewer
-        mock = double('reflection', :options => {:class_name => 'Author'}, :klass => ::Author, :macro => :belongs_to)
+        mock = double('reflection', :scope => nil, :options => {:class_name => 'Author'}, :klass => ::Author, :macro => :belongs_to)
         allow(mock).to receive(:[]).with(:class_name).and_return("Author")
         mock
       when :authors
-        double('reflection', :options => {}, :klass => ::Author, :macro => :has_and_belongs_to_many)
+        double('reflection', :scope => nil, :options => {}, :klass => ::Author, :macro => :has_and_belongs_to_many)
       when :sub_posts
-        double('reflection', :options => {}, :klass => ::Post, :macro => :has_many)
+        double('reflection', :scope => nil, :options => {}, :klass => ::Post, :macro => :has_many)
       when :main_post
-        double('reflection', :options => {}, :klass => ::Post, :macro => :belongs_to)
+        double('reflection', :scope => nil, :options => {}, :klass => ::Post, :macro => :belongs_to)
       when :mongoid_reviewer
         ::MongoidReflectionMock.new('reflection',
+             :scope => nil,
              :options => Proc.new { raise NoMethodError, "Mongoid has no reflection.options" },
              :klass => ::Author, :macro => :referenced_in, :foreign_key => "reviewer_id") # custom id
       end


### PR DESCRIPTION
Rails has relaced the `:conditions` relationships' option with optional lambda/proc `scopes` for a long time already. It just makes sense for Formtastic to support them the same way it does for the `:conditions` option.

Given this code:

```ruby
class Post < ApplicationRecord
  belongs_to :author, -> { active.order(name: :asc) }
end

class Author < ApplicationRecord
  scope :active, -> { where(active: true) }
end
```

```slim
- semantic_form_for(Post.new) do |f|
  = f.input :author
```

Without this change the autogenerated select input with the list of authors will include ALL authors because it effectivelly loads the list from `Post.all`. After this change, the list will be filled with `Post.active.order(name: :asc)` because the `belongs_to` relationship includes a scope.

This seems to bring parity to the old way of applying conditions to relationships via the `:conditions` option which got deprecated back in Rails 4.